### PR TITLE
Fix typo in path for getPlaylistsData

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function RLSClient(options) {
     };
 
     self.getPlaylistsData = function (callback) {
-        self._call('/data/seasons', callback);
+        self._call('/data/playlists', callback);
     };
 
     self.getTiersData = function (callback) {


### PR DESCRIPTION
Fixes #8 - getPlaylistsData was querying the endpoint for seasons data instead of the endpoint for playlist data